### PR TITLE
Copy filename as part of path

### DIFF
--- a/MyStreamTimer.Shared/ViewModel/TimerViewModel.cs
+++ b/MyStreamTimer.Shared/ViewModel/TimerViewModel.cs
@@ -155,6 +155,7 @@ namespace MyStreamTimer.Shared.ViewModel
         void ExecuteCopyFilePathCommand()
         {
             var directory = GetDirectory();
+            directory = Path.Combine(directory, FileName);
             var clipboard = ServiceContainer.Resolve<IClipboard>();
             clipboard?.CopyToClipboard(directory);
         }


### PR DESCRIPTION
The copy button behind the filename was copying just the path not including the filename.

This change fixes that